### PR TITLE
Add CI workflow for Composer and PHP tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.x'
+          cache: 'composer'
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction
+      - name: Lint
+        run: vendor/bin/phpcs
+      - name: Test
+        run: vendor/bin/phpunit


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for PHP projects using Composer

## Testing
- `composer install --prefer-dist --no-interaction` *(fails: CONNECT tunnel failed 403 while cloning dragonmantank/cron-expression)*
- `vendor/bin/phpcs` *(fails: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68aecd3470088330a2787b5bc13c0464