### PR TITLE
Add default user seeder for admin, manager, and teacher

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,8 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,11 +11,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        $this->call(UserSeeder::class);
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $users = [
+            [
+                'name' => 'Admin',
+                'email' => 'admin@example.com',
+                'password' => Hash::make('password'),
+            ],
+            [
+                'name' => 'Manager',
+                'email' => 'manager@example.com',
+                'password' => Hash::make('password'),
+            ],
+            [
+                'name' => 'Teacher',
+                'email' => 'teacher@example.com',
+                'password' => Hash::make('password'),
+            ],
+        ];
+
+        foreach ($users as $user) {
+            User::create($user);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- seed admin, manager, and teacher accounts with default credentials
- invoke UserSeeder from DatabaseSeeder

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*
- `composer install` *(fails: Failed to download doctrine/inflector from dist: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_b_68aed4f97bac83308a6d4e4266681510